### PR TITLE
Remove language code from AMO link

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 				<a class="button" href="https://chrome.google.com/webstore/detail/npmhub/kbbbjimdjbjclaebffknlabpogocablj">
 					For Google Chrome
 				</a>
-				<a class="button" href="https://addons.mozilla.org/en-US/firefox/addon/npm-hub/">
+				<a class="button" href="https://addons.mozilla.org/firefox/addon/npm-hub/">
 					For Firefox
 				</a>
 				<a class="button" href="https://apps.apple.com/app/npmhub/id1542090429">


### PR DESCRIPTION
A little nitpicking, but it's the same reason as https://github.com/refined-github/refined-github/commit/9ab61d196a2a565d7af4592bbdfc0ef17715d5f6.

You may also be interested in applying this change to a few other AMO links:
- https://github.com/npmhub/npmhub/blob/main/README.md
- ~~https://github.com/fregante/ghosttext.fregante.com/blob/main/index.md~~ included in another PR